### PR TITLE
ENG-1783 Tuva 0.8.6 support for postgres

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -40,6 +40,10 @@ vars:
     # Default timezone is UTC
     tuva_last_run: '{{ run_started_at.astimezone(modules.pytz.timezone("UTC")) }}'
 
+
+    ## Tuva seed S3 bucket override (for PG only)
+    #tuva_seeds_s3_bucket: "tuva-public-resources"
+
 on-run-end:
   - "{{ log_warning_for_seeds() }}"
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -41,8 +41,9 @@ vars:
     tuva_last_run: '{{ run_started_at.astimezone(modules.pytz.timezone("UTC")) }}'
 
 
-    ## Tuva seed S3 bucket override (for PG only)
+    ## Tuva seed S3 bucket override (for PG only) - also optional prefix in case the bucket has other content
     #tuva_seeds_s3_bucket: "tuva-public-resources"
+    #tuva_seeds_s3_key_prefix: "tuva/seeds/example/prefix"
 
 on-run-end:
   - "{{ log_warning_for_seeds() }}"

--- a/macros/escape_quotes.sql
+++ b/macros/escape_quotes.sql
@@ -1,0 +1,20 @@
+{#
+    The built-in dbt.string_literal doesn''t seem to escape quotes properly.
+    This primarily affects postgres where ' must be entered as '' but on other platforms it is \'.
+#}
+
+{% macro escape_quotes(value) %}
+{{ return(adapter.dispatch('escape_quotes', 'the_tuva_project')(value)) }}
+{% endmacro %}
+
+
+
+{% macro postgres__escape_quotes(value) %}
+  {{ value | replace("'", "''") }}
+{% endmacro %}
+
+
+
+{% macro default__escape_quotes(value) %}
+  {{ value | replace("'", "\\'") }}
+{% endmacro %}

--- a/macros/get_selected_seeds.sql
+++ b/macros/get_selected_seeds.sql
@@ -7,7 +7,7 @@
 
     {% for node in nodes %}
         {% if node.resource_type == 'seed' and node.unique_id in selected_nodes and node.package_name in['the_tuva_project','tuva'] %}
-            {% set fully_qualified_name = node.database ~ '.' ~ node.schema ~ '.' ~ node.alias %}
+            {% set fully_qualified_name = adapter.quote(node.database) ~ '.' ~ node.schema ~ '.' ~ node.alias %}
             {% do ns.selected_seeds.append(fully_qualified_name) %}
         {% endif %}
     {% endfor %}

--- a/macros/get_selected_seeds.sql
+++ b/macros/get_selected_seeds.sql
@@ -6,8 +6,24 @@
     {% set ns = namespace(selected_seeds=[]) %}
 
     {% for node in nodes %}
-        {% if node.resource_type == 'seed' and node.unique_id in selected_nodes and node.package_name in['the_tuva_project','tuva'] %}
-            {% set fully_qualified_name = adapter.quote(node.database) ~ '.' ~ node.schema ~ '.' ~ node.alias %}
+        {% if node.resource_type == 'seed' and node.unique_id in selected_nodes and node.package_name in['the_tuva_project','tuva','integration_tests'] %}
+            {% if adapter.config.quoting.database %}
+                {% set db =adapter.quote(node.database) %}
+            {% else %}
+                {% set db = node.database %}
+            {% endif %}
+            {% if adapter.config.quoting.schema %}
+                {% set sch =adapter.quote(node.schema) %}
+            {% else %}
+                {% set sch = node.schema %}
+            {% endif %}
+            {% if adapter.config.quoting.identifier %}
+                {% set idf =adapter.quote(node.alias) %}
+            {% else %}
+                {% set idf = node.alias %}
+            {% endif %}
+            {% set fully_qualified_name = db ~ '.' ~ sch ~ '.' ~ idf %}
+
             {% do ns.selected_seeds.append(fully_qualified_name) %}
         {% endif %}
     {% endfor %}

--- a/macros/load_seed.sql
+++ b/macros/load_seed.sql
@@ -222,6 +222,51 @@ COPY_OPTIONS (
 
 
 
+{% macro postgres__load_seed(uri,pattern,compression,headers,null_marker) %}
+{%- set columns = adapter.get_columns_in_relation(this) -%}
+{%- set collist = [] -%}
+
+{% for col in columns %}
+  {% do collist.append(col.name) %}
+{% endfor %}
+
+{%- set cols = collist|join(',') -%}
+
+{%- set null_string = '\'\'\\\\N\'\'' if null_marker == true else "''''" -%}
+
+{% set sql %}
+DO $$
+BEGIN
+    BEGIN
+        PERFORM aws_s3.table_import_from_s3(
+            '{{ this }}',
+            '{{ cols }}',
+            '(FORMAT csv, HEADER false, NULL  {{ null_string }} , ENCODING UTF8)',  -- Ensure the correct encoding is specified (UTF8)
+            aws_commons.create_s3_uri('tuva-public-resources', '{{ uri.replace('tuva-public-resources/', '') }}/{{ pattern }}_0_0_0.csv.gz', 'us-east-1'),
+            aws_commons.create_aws_credentials('AKIA2EPVNTV4FLAEBFGE', 'TARgblERrFP81Op+52KZW7HrP1Om6ObEDQAUVN2u', '')
+        );
+    EXCEPTION
+        WHEN OTHERS THEN
+            NULL;  -- Silently handle any exceptions
+    END;
+END $$;
+{% endset %}
+
+{% call statement('postgressql',fetch_result=true) %}
+{{ sql }}
+{% endcall %}
+
+{% if execute %}
+{# debugging { log(sql, True)} #}
+{% set results = load_result('postgressql') %}
+{{ log("Loaded data from external s3 resource\n  loaded to: " ~ this ~ "\n  from: s3://" ~ uri ,True) }}
+{# debugging { log(results, True) } #}
+{% endif %}
+
+{% endmacro %}
+
+
+
 {% macro default__load_seed(uri,pattern,compression,headers,null_marker) %}
 {% if execute %}
 {% do log('No adapter found, seed not loaded',info = True) %}

--- a/macros/load_seed.sql
+++ b/macros/load_seed.sql
@@ -240,7 +240,7 @@ COPY_OPTIONS (
 {%- set s3_bucket = var("tuva_seeds_s3_bucket", uri.split("/")[0]) -%}
 {%- set s3_key = uri.split("/")[1:]|join("/") + "/" + pattern + "_0.csv.gz" -%}
 {%- if var("tuva_seeds_s3_key_prefix", "") != "" -%}
-{%- do s3_key = var("tuva_seeds_s3_key_prefix") + "/" + s3_key -%}
+{%- set s3_key = var("tuva_seeds_s3_key_prefix") + "/" + s3_key -%}
 {%- endif -%}
 {%- set s3_region = "us-east-1" -%}
 {%- set options = ["(", "format csv", ", encoding ''utf8''"] -%}

--- a/macros/load_seed.sql
+++ b/macros/load_seed.sql
@@ -222,6 +222,54 @@ COPY_OPTIONS (
 
 
 
+-- postgres - note this requires some pre-work on your part you need to clone
+-- the data from the tuva public resource bucket to re-assemble it into a single
+-- file per seed - also ensure you've set the Content-Type system header on each
+-- to be gzip (https://stackoverflow.com/a/74439053) otherwise the extension
+-- won't know to decompress it.
+--
+-- TODO: revisit removing column list, I think it'll work fine with '' for cols
+{% macro postgres__load_seed(uri,pattern,compression,headers,null_marker) %}
+{%- set columns = adapter.get_columns_in_relation(this) -%}
+{%- set collist = [] -%}
+{%- for col in columns -%}
+  {%- do collist.append(col.name) -%}
+{%- endfor -%}
+{%- set cols = collist|join(",") -%}
+
+{%- set s3_bucket = uri.split("/")[0] -%}
+{%- set s3_key = uri.split("/")[1:]|join("/") + "/" + pattern + "_0_0_0.csv.gz" -%}
+{%- set s3_region = "us-east-1" -%}
+{%- set options = ["(", "format csv", ", encoding ''utf8''"] -%}
+{%- do options.append(", null ''\\N''") if null_marker == true -%}
+{%- do options.append(")") -%}
+{%- set options_s = options | join("") -%}
+
+{% set sql %}
+SELECT aws_s3.table_import_from_s3(
+   '{{ this }}',
+   '{{ cols }}',
+   '{{ options_s }}',
+   aws_commons.create_s3_uri('{{s3_bucket}}', '{{s3_key}}', '{{s3_region}}'),
+   aws_commons.create_aws_credentials('AKIA2EPVNTV4FLAEBFGE', 'TARgblERrFP81Op+52KZW7HrP1Om6ObEDQAUVN2u', '')
+)
+{% endset %}
+
+{% call statement('postgressql',fetch_result=true) %}
+{{ sql }}
+{% endcall %}
+
+{% if execute %}
+{# debugging { log(sql, True)} #}
+{% set results = load_result('postgressql') %}
+{{ log("Loaded data from external s3 resource\n  loaded to: " ~ this ~ "\n  from: s3://" ~ s3_bucket ~ "/" ~ s3_key ,True) }}
+{# debugging { log(results, True) } #}
+{% endif %}
+
+{% endmacro %}
+
+
+
 {% macro default__load_seed(uri,pattern,compression,headers,null_marker) %}
 {% if execute %}
 {% do log('No adapter found, seed not loaded',info = True) %}

--- a/macros/load_seed.sql
+++ b/macros/load_seed.sql
@@ -237,8 +237,11 @@ COPY_OPTIONS (
 {%- endfor -%}
 {%- set cols = collist|join(",") -%}
 
-{%- set s3_bucket = uri.split("/")[0] -%}
-{%- set s3_key = uri.split("/")[1:]|join("/") + "/" + pattern + "_0_0_0.csv.gz" -%}
+{%- set s3_bucket = var("tuva_seeds_s3_bucket", uri.split("/")[0]) -%}
+{%- set s3_key = uri.split("/")[1:]|join("/") + "/" + pattern + "_0.csv.gz" -%}
+{%- if var("tuva_seeds_s3_key_prefix", "") != "" -%}
+{%- do s3_key = var("tuva_seeds_s3_key_prefix") + "/" + s3_key -%}
+{%- endif -%}
 {%- set s3_region = "us-east-1" -%}
 {%- set options = ["(", "format csv", ", encoding ''utf8''"] -%}
 {%- do options.append(", null ''\\N''") if null_marker == true -%}
@@ -250,8 +253,7 @@ SELECT aws_s3.table_import_from_s3(
    '{{ this }}',
    '{{ cols }}',
    '{{ options_s }}',
-   aws_commons.create_s3_uri('{{s3_bucket}}', '{{s3_key}}', '{{s3_region}}'),
-   aws_commons.create_aws_credentials('AKIA2EPVNTV4FLAEBFGE', 'TARgblERrFP81Op+52KZW7HrP1Om6ObEDQAUVN2u', '')
+   aws_commons.create_s3_uri('{{s3_bucket}}', '{{s3_key}}', '{{s3_region}}')
 )
 {% endset %}
 

--- a/models/ahrq_measures/pqi/pqi_models.yml
+++ b/models/ahrq_measures/pqi/pqi_models.yml
@@ -251,7 +251,7 @@ models:
     config:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
-          {var('tuva_schema_prefix')}_ahrq_measures
+          {{var('tuva_schema_prefix')}}_ahrq_measures
         {% else %}
           ahrq_measures
         {%- endif -%}
@@ -267,7 +267,7 @@ models:
     config:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
-          {var('tuva_schema_prefix')}_ahrq_measures
+          {{var('tuva_schema_prefix')}}_ahrq_measures
         {% else %}
           ahrq_measures
         {%- endif -%}
@@ -283,7 +283,7 @@ models:
     config:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
-          {var('tuva_schema_prefix')}_ahrq_measures
+          {{var('tuva_schema_prefix')}}_ahrq_measures
         {% else %}
           ahrq_measures
         {%- endif -%}
@@ -299,7 +299,7 @@ models:
     config:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
-          {var('tuva_schema_prefix')}_ahrq_measures
+          {{var('tuva_schema_prefix')}}_ahrq_measures
         {% else %}
           ahrq_measures
         {%- endif -%}
@@ -315,7 +315,7 @@ models:
     config:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
-          {var('tuva_schema_prefix')}_ahrq_measures
+          {{var('tuva_schema_prefix')}}_ahrq_measures
         {% else %}
           ahrq_measures
         {%- endif -%}
@@ -331,7 +331,7 @@ models:
     config:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
-          {var('tuva_schema_prefix')}_ahrq_measures
+          {{var('tuva_schema_prefix')}}_ahrq_measures
         {% else %}
           ahrq_measures
         {%- endif -%}
@@ -347,7 +347,7 @@ models:
     config:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
-          {var('tuva_schema_prefix')}_ahrq_measures
+          {{var('tuva_schema_prefix')}}_ahrq_measures
         {% else %}
           ahrq_measures
         {%- endif -%}
@@ -363,7 +363,7 @@ models:
     config:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
-          {var('tuva_schema_prefix')}_ahrq_measures
+          {{var('tuva_schema_prefix')}}_ahrq_measures
         {% else %}
           ahrq_measures
         {%- endif -%}
@@ -380,7 +380,7 @@ models:
     config:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
-          {var('tuva_schema_prefix')}_ahrq_measures
+          {{var('tuva_schema_prefix')}}_ahrq_measures
         {% else %}
           ahrq_measures
         {%- endif -%}
@@ -396,7 +396,7 @@ models:
     config:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
-          {var('tuva_schema_prefix')}_ahrq_measures
+          {{var('tuva_schema_prefix')}}_ahrq_measures
         {% else %}
           ahrq_measures
         {%- endif -%}
@@ -412,7 +412,7 @@ models:
     config:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
-          {var('tuva_schema_prefix')}_ahrq_measures
+          {{var('tuva_schema_prefix')}}_ahrq_measures
         {% else %}
           ahrq_measures
         {%- endif -%}
@@ -428,7 +428,7 @@ models:
     config:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
-          {var('tuva_schema_prefix')}_ahrq_measures
+          {{var('tuva_schema_prefix')}}_ahrq_measures
         {% else %}
           ahrq_measures
         {%- endif -%}
@@ -444,7 +444,7 @@ models:
     config:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
-          {var('tuva_schema_prefix')}_ahrq_measures
+          {{var('tuva_schema_prefix')}}_ahrq_measures
         {% else %}
           ahrq_measures
         {%- endif -%}
@@ -460,7 +460,7 @@ models:
     config:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
-          {var('tuva_schema_prefix')}_ahrq_measures
+          {{var('tuva_schema_prefix')}}_ahrq_measures
         {% else %}
           ahrq_measures
         {%- endif -%}
@@ -476,7 +476,7 @@ models:
     config:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
-          {var('tuva_schema_prefix')}_ahrq_measures
+          {{var('tuva_schema_prefix')}}_ahrq_measures
         {% else %}
           ahrq_measures
         {%- endif -%}
@@ -492,7 +492,7 @@ models:
     config:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
-          {var('tuva_schema_prefix')}_ahrq_measures
+          {{var('tuva_schema_prefix')}}_ahrq_measures
         {% else %}
           ahrq_measures
         {%- endif -%}
@@ -508,7 +508,7 @@ models:
     config:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
-          {var('tuva_schema_prefix')}_ahrq_measures
+          {{var('tuva_schema_prefix')}}_ahrq_measures
         {% else %}
           ahrq_measures
         {%- endif -%}
@@ -524,7 +524,7 @@ models:
     config:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
-          {var('tuva_schema_prefix')}_ahrq_measures
+          {{var('tuva_schema_prefix')}}_ahrq_measures
         {% else %}
           ahrq_measures
         {%- endif -%}
@@ -540,7 +540,7 @@ models:
     config:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
-          {var('tuva_schema_prefix')}_ahrq_measures
+          {{var('tuva_schema_prefix')}}_ahrq_measures
         {% else %}
           ahrq_measures
         {%- endif -%}
@@ -556,7 +556,7 @@ models:
     config:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
-          {var('tuva_schema_prefix')}_ahrq_measures
+          {{var('tuva_schema_prefix')}}_ahrq_measures
         {% else %}
           ahrq_measures
         {%- endif -%}
@@ -572,7 +572,7 @@ models:
     config:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
-          {var('tuva_schema_prefix')}_ahrq_measures
+          {{var('tuva_schema_prefix')}}_ahrq_measures
         {% else %}
           ahrq_measures
         {%- endif -%}
@@ -588,7 +588,7 @@ models:
     config:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
-          {var('tuva_schema_prefix')}_ahrq_measures
+          {{var('tuva_schema_prefix')}}_ahrq_measures
         {% else %}
           ahrq_measures
         {%- endif -%}
@@ -604,7 +604,7 @@ models:
     config:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
-          {var('tuva_schema_prefix')}_ahrq_measures
+          {{var('tuva_schema_prefix')}}_ahrq_measures
         {% else %}
           ahrq_measures
         {%- endif -%}
@@ -620,7 +620,7 @@ models:
     config:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
-          {var('tuva_schema_prefix')}_ahrq_measures
+          {{var('tuva_schema_prefix')}}_ahrq_measures
         {% else %}
           ahrq_measures
         {%- endif -%}
@@ -636,7 +636,7 @@ models:
     config:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
-          {var('tuva_schema_prefix')}_ahrq_measures
+          {{var('tuva_schema_prefix')}}_ahrq_measures
         {% else %}
           ahrq_measures
         {%- endif -%}
@@ -652,7 +652,7 @@ models:
     config:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
-          {var('tuva_schema_prefix')}_ahrq_measures
+          {{var('tuva_schema_prefix')}}_ahrq_measures
         {% else %}
           ahrq_measures
         {%- endif -%}
@@ -668,7 +668,7 @@ models:
     config:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
-          {var('tuva_schema_prefix')}_ahrq_measures
+          {{var('tuva_schema_prefix')}}_ahrq_measures
         {% else %}
           ahrq_measures
         {%- endif -%}

--- a/models/chronic_conditions/final/chronic_conditions__tuva_chronic_conditions_wide.sql
+++ b/models/chronic_conditions/final/chronic_conditions__tuva_chronic_conditions_wide.sql
@@ -120,7 +120,7 @@ where condition = 'Ulcerative colitis'
 chrohns as (
 select distinct patient_id
 from {{ ref('chronic_conditions__tuva_chronic_conditions_long')  }}
-where condition = {{ escape_quotes("Chrohn's Disease") }}
+where condition = {{ dbt.string_literal(escape_quotes("Chrohn's Disease")) }}
 ),
 
 holicobacter as (

--- a/models/chronic_conditions/final/chronic_conditions__tuva_chronic_conditions_wide.sql
+++ b/models/chronic_conditions/final/chronic_conditions__tuva_chronic_conditions_wide.sql
@@ -120,7 +120,7 @@ where condition = 'Ulcerative colitis'
 chrohns as (
 select distinct patient_id
 from {{ ref('chronic_conditions__tuva_chronic_conditions_long')  }}
-where condition = 'Chrohn\'s Disease'
+where condition = {{ escape_quotes("Chrohn's Disease") }}
 ),
 
 holicobacter as (


### PR DESCRIPTION
* backport fix for database name quoting in seed checker
* fix for pg-friendly quoting of string data (not necessary in 0.9.0)
* pg load-seed implementation that relies on aws_s3 plus [pg-friendly formatted version of seed data](https://github.com/waymark-care/tuva-postgres-seed-loader/pull/1)
* Fix for bug in tuva prefix var in the pqi models yml file