### PR TITLE
Service type bug

### DIFF
--- a/models/claims_preprocessing/service_category/intermediate/service_category__acute_inpatient_institutional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__acute_inpatient_institutional.sql
@@ -50,7 +50,7 @@ select distinct
 from {{ ref('service_category__stg_medical_claim') }} a
 inner join room_and_board_requirement b
   on a.claim_id = b.claim_id
-inner join drg_requirement c
-  on a.claim_id = c.claim_id
+-- inner join drg_requirement c
+--   on a.claim_id = c.claim_id
 inner join bill_type_requirement d
   on a.claim_id = d.claim_id


### PR DESCRIPTION
we don't have drgs from all our mcos, this caused service type to be misclassified for inpatient events.  Also bill type is sufficient and. drgs are not really necessary. Also, this a similar change is already in a newer tuva version

## Describe your changes
Please include a summary of any changes.


## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.


## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
