### PR TITLE
i think this is more correct, plus admission dates are mostly off

### DIFF
--- a/models/core/staging/core__stg_claims_procedure.sql
+++ b/models/core/staging/core__stg_claims_procedure.sql
@@ -15,11 +15,7 @@ select
     claim_id as claim_id
   , patient_id as patient_id
   , claim_line_number as proc_seq_id
-  , coalesce(admission_date
-           , claim_start_date
-           , discharge_date
-           , claim_end_date
-    ) as procedure_date
+  , claim_line_start_date as procedure_date
   , 'hcpcs' as source_code_type
   , hcpcs_code as source_code
   , rendering_npi as practitioner_npi


### PR DESCRIPTION
## Describe your changes
Please include a summary of any changes.
noticed a lot of proc dates 1900-01-01. turn out there was a coalse that prioritizes admission date first. also this didnt use line date, which seems the most germain to me, and for things like HEDIS, exact date matters, so not sure we want this to be how we calc proc dates.

I brought this up to Tuva Health, and will put in a PR if they agree

## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.


## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
